### PR TITLE
[Feature] add range header when fetching image

### DIFF
--- a/lib/getRaw.js
+++ b/lib/getRaw.js
@@ -13,7 +13,10 @@ function formatShutterTime(shutterTime) {
 
 async function getRaw(url) {
   try {
-    const response = await fetch(url);
+    // Fetch first 71680 bytes as maximum exif length is 64KB.
+    const response = await fetch(url, {
+      headers: { Range: "bytes=0-71680" },
+    });
     const data = new Uint8Array(await response.arrayBuffer());
     const rawData = await exifr.parse(data);
     const image = new Raw({


### PR DESCRIPTION
EXIF信息最大长度为64KB，且在图片文件开头。

因此请求图片时可以指定range header，只获取图片文件的前面最多70KB字节。

可以降低解析图片的带宽消耗。

Reference:
- https://www.cnblogs.com/doit8791/p/6107254.html